### PR TITLE
219 adding preview responses for everything

### DIFF
--- a/hms-api/dev/http/http-client.env.json
+++ b/hms-api/dev/http/http-client.env.json
@@ -1,7 +1,7 @@
 {
   "local": {
     "host": "http://localhost:4566",
-    "api_id": "h9dbuprxb3",
+    "api_id": "fv1ql8jx54",
     "hackathon_id": "e955fe4b-7ce7-4904-ae6f-22a8985f74a8",
     "category_id": "7f38993d-073a-4932-af79-07440012f268",
     "idea_id": "cd760a62-6c79-44f0-96f0-f2e87bd5f169",

--- a/hms-api/src/handlers/category/get.ts
+++ b/hms-api/src/handlers/category/get.ts
@@ -1,16 +1,19 @@
 import {buildResponse} from '../../rest/responses';
 import {getCategory} from '../../repository/category-repository';
 import CategoryResponse from '../../rest/CategoryResponse';
+import {getHackathon} from '../../repository/hackathon-repository';
+import HackathonPreviewResponse from '../../rest/HackathonPreviewResponse';
 
 // eslint-disable-next-line require-jsdoc
 export async function get(event, context, callback) {
   const category = await getCategory(event.pathParameters.id);
   if (category) {
+    const hackathon = await getHackathon(category.hackathonId);
     const responseBody = new CategoryResponse(
         category.id,
         category.title,
         category.description,
-        category.hackathonId,
+        HackathonPreviewResponse.from(hackathon),
     );
 
     callback(null, buildResponse(200, responseBody));

--- a/hms-api/src/handlers/category/list.ts
+++ b/hms-api/src/handlers/category/list.ts
@@ -2,16 +2,14 @@ import {Uuid} from '../../util/uuids';
 import {buildResponse} from '../../rest/responses';
 import {listCategories} from '../../repository/category-repository';
 import CategoryListResponse from '../../rest/CategoryListResponse';
+import CategoryPreviewResponse from '../../rest/CategoryPreviewResponse';
 
 // eslint-disable-next-line require-jsdoc
 export async function list(event, context, callback) {
   const hackathonId: Uuid = event.pathParameters.hackathonId;
-  const categories = await listCategories(hackathonId);
-
-  const categoryIds = categories.map((category) => category.id);
-  const response = buildResponse(
+  const previews = CategoryPreviewResponse.fromArray(
+      await listCategories(hackathonId));
+  callback(null, buildResponse(
       200,
-      new CategoryListResponse(categoryIds, hackathonId));
-
-  callback(null, response);
+      new CategoryListResponse(previews, hackathonId)));
 }

--- a/hms-api/src/handlers/hackathon/get.ts
+++ b/hms-api/src/handlers/hackathon/get.ts
@@ -1,19 +1,31 @@
+/* eslint-disable require-jsdoc */
+
 import {buildResponse} from '../../rest/responses';
 import {getHackathon} from '../../repository/hackathon-repository';
 import HackathonResponse from '../../rest/HackathonResponse';
+import {listParticipants} from '../../repository/participant-repository';
+import ParticipantPreviewResponse from '../../rest/ParticipantPreviewResponse';
+import {listCategories} from '../../repository/category-repository';
+import CategoryPreviewResponse from '../../rest/CategoryPreviewResponse';
+import IdeaPreviewResponse from '../../rest/IdeaPreviewResponse';
+import {listIdeas} from '../../repository/idea-repository';
+import {usersFor} from '../../service/user-service';
 
-// eslint-disable-next-line require-jsdoc
 export async function get(event, context, callback) {
   const hackathon = await getHackathon(event.pathParameters.id);
   if (hackathon) {
+    const participants = await listParticipants(event.pathParameters.id);
+    const participantPreviews = ParticipantPreviewResponse.fromArray(
+        participants,
+        await usersFor(participants));
     const responseBody = new HackathonResponse(
         hackathon.id,
         hackathon.title,
         hackathon.startDate,
         hackathon.endDate,
-        hackathon.participantIds,
-        hackathon.categoryIds,
-        hackathon.ideaIds,
+        participantPreviews,
+        CategoryPreviewResponse.fromArray(await listCategories(hackathon.id)),
+        IdeaPreviewResponse.fromArray(await listIdeas(hackathon.id)),
     );
 
     callback(null, buildResponse(200, responseBody));

--- a/hms-api/src/handlers/hackathon/list.ts
+++ b/hms-api/src/handlers/hackathon/list.ts
@@ -1,13 +1,10 @@
 import {buildResponse} from '../../rest/responses';
 import {listHackathons} from '../../repository/hackathon-repository';
 import HackathonListResponse from '../../rest/HackathonListResponse';
+import HackathonPreviewResponse from '../../rest/HackathonPreviewResponse';
 
 // eslint-disable-next-line require-jsdoc
 export async function list(event, context, callback) {
-  const hackathons = await listHackathons();
-
-  const hackathonIds = hackathons.map((hackathon) => hackathon.id);
-  const response = buildResponse(200, new HackathonListResponse(hackathonIds));
-
-  callback(null, response);
+  const previews = HackathonPreviewResponse.fromArray(await listHackathons());
+  callback(null, buildResponse(200, new HackathonListResponse(previews)));
 }

--- a/hms-api/src/handlers/idea/get.ts
+++ b/hms-api/src/handlers/idea/get.ts
@@ -1,23 +1,41 @@
 import {buildResponse} from '../../rest/responses';
 import {getIdea} from '../../repository/idea-repository';
 import IdeaResponse from '../../rest/IdeaResponse';
+import {getUser} from '../../repository/user-repository';
+import participantPreviewResponse from '../../rest/ParticipantPreviewResponse';
+import ParticipantPreviewResponse from '../../rest/ParticipantPreviewResponse';
+import {
+  getParticipant,
+  getParticipants,
+} from '../../repository/participant-repository';
+import {getHackathon} from '../../repository/hackathon-repository';
+import HackathonPreviewResponse from '../../rest/HackathonPreviewResponse';
+import SkillPreviewResponse from '../../rest/SkillPreviewResponse';
+import {getSkills} from '../../repository/skill-repository';
+import CategoryPreviewResponse from '../../rest/CategoryPreviewResponse';
+import {getCategory} from '../../repository/category-repository';
+import {usersFor} from '../../service/user-service';
 
 // eslint-disable-next-line require-jsdoc
 export async function get(event, context, callback) {
   const idea = await getIdea(event.pathParameters.id);
 
   if (idea) {
+    const owner = await getParticipant(idea.ownerId);
+    const participants = await getParticipants(idea.participantIds);
+    const users = await usersFor(participants);
+    const skills = await getSkills(idea.requiredSkills);
     const responseBody = new IdeaResponse(
         idea.id,
-        idea.ownerId,
-        idea.hackathonId,
-        idea.participantIds,
+        participantPreviewResponse.from(owner, await getUser(owner.userId)),
+        HackathonPreviewResponse.from(await getHackathon(idea.hackathonId)),
+        ParticipantPreviewResponse.fromArray(participants, users),
         idea.title,
         idea.description,
         idea.problem,
         idea.goal,
-        idea.requiredSkills,
-        idea.categoryId,
+        SkillPreviewResponse.fromArray(skills),
+        CategoryPreviewResponse.from(await getCategory(idea.categoryId)),
         idea.creationDate,
     );
 

--- a/hms-api/src/handlers/idea/list.ts
+++ b/hms-api/src/handlers/idea/list.ts
@@ -2,16 +2,13 @@ import {Uuid} from '../../util/uuids';
 import {buildResponse} from '../../rest/responses';
 import {listIdeas} from '../../repository/idea-repository';
 import IdeaListResponse from '../../rest/IdeaListResponse';
+import IdeaPreviewResponse from '../../rest/IdeaPreviewResponse';
 
 // eslint-disable-next-line require-jsdoc
 export async function list(event, context, callback) {
   const hackathonId: Uuid = event.pathParameters.hackathonId;
-  const ideas = await listIdeas(hackathonId);
-
-  const ideaIds = ideas.map((idea) => idea.id);
-  const response = buildResponse(
+  const previews = IdeaPreviewResponse.fromArray(await listIdeas(hackathonId));
+  callback(null, buildResponse(
       200,
-      new IdeaListResponse(ideaIds, hackathonId));
-
-  callback(null, response);
+      new IdeaListResponse(previews, hackathonId)));
 }

--- a/hms-api/src/handlers/participant/get.ts
+++ b/hms-api/src/handlers/participant/get.ts
@@ -1,16 +1,22 @@
 import {buildResponse} from '../../rest/responses';
 import {getParticipant} from '../../repository/participant-repository';
 import ParticipantResponse from '../../rest/ParticipantResponse';
+import HackathonPreviewResponse from '../../rest/HackathonPreviewResponse';
+import {getHackathon} from '../../repository/hackathon-repository';
+import UserPreviewResponse from '../../rest/UserPreviewResponse';
+import {getUser} from '../../repository/user-repository';
 
 // eslint-disable-next-line require-jsdoc
 export async function get(event, context, callback) {
   const participant = await getParticipant(event.pathParameters.id);
 
   if (participant) {
+    const user = await getUser(participant.userId);
+    const hackathon = await getHackathon(participant.hackathonId);
     const responseBody = new ParticipantResponse(
         participant.userId,
-        participant.hackathonId,
-        participant.id,
+        UserPreviewResponse.from(user),
+        HackathonPreviewResponse.from(hackathon),
         participant.creationDate,
     );
 

--- a/hms-api/src/handlers/participant/list.ts
+++ b/hms-api/src/handlers/participant/list.ts
@@ -2,16 +2,16 @@ import {Uuid} from '../../util/uuids';
 import {buildResponse} from '../../rest/responses';
 import {listParticipants} from '../../repository/participant-repository';
 import ParticipantListResponse from '../../rest/ParticipantListResponse';
+import ParticipantPreviewResponse from '../../rest/ParticipantPreviewResponse';
+import {usersFor} from '../../service/user-service';
 
 // eslint-disable-next-line require-jsdoc
 export async function list(event, context, callback) {
   const hackathonId: Uuid = event.pathParameters.hackathonId;
   const participants = await listParticipants(hackathonId);
+  const users = await usersFor(participants);
+  const previews = ParticipantPreviewResponse.fromArray(participants, users);
+  const responseBody = new ParticipantListResponse(previews, hackathonId);
 
-  const participantIds = participants.map((participant) => participant.id);
-  const response = buildResponse(
-      200,
-      new ParticipantListResponse(participantIds, hackathonId));
-
-  callback(null, response);
+  callback(null, buildResponse(200, responseBody));
 }

--- a/hms-api/src/handlers/skill/list.ts
+++ b/hms-api/src/handlers/skill/list.ts
@@ -1,11 +1,10 @@
 import {buildResponse} from '../../rest/responses';
 import {listSkills} from '../../repository/skill-repository';
 import SkillListResponse from '../../rest/SkillListResponse';
-import {mapSkillToSkillPreview} from '../../rest/SkillPreviewResponse';
+import SkillPreviewResponse from '../../rest/SkillPreviewResponse';
 
 // eslint-disable-next-line require-jsdoc
 export async function list(event, context, callback) {
-  const skills = await listSkills();
-  const skillPreviews = skills.map((skill) => mapSkillToSkillPreview(skill));
-  callback(null, buildResponse(200, new SkillListResponse(skillPreviews)));
+  const previews = SkillPreviewResponse.fromArray(await listSkills());
+  callback(null, buildResponse(200, new SkillListResponse(previews)));
 }

--- a/hms-api/src/handlers/user/get.ts
+++ b/hms-api/src/handlers/user/get.ts
@@ -3,7 +3,7 @@ import {buildResponse} from '../../rest/responses';
 import {getUser} from '../../repository/user-repository';
 import UserResponse from '../../rest/UserResponse';
 import {mapRolesToStrings} from '../../repository/domain/Role';
-import {mapSkillToSkillPreview} from '../../rest/SkillPreviewResponse';
+import SkillPreviewResponse from '../../rest/SkillPreviewResponse';
 import {getSkills} from '../../repository/skill-repository';
 
 // eslint-disable-next-line require-jsdoc
@@ -12,15 +12,13 @@ export async function get(event, context, callback) {
   const user = await getUser(id);
 
   if (user) {
-    const skills = await getSkills(user.skills);
-
     const responseBody = new UserResponse(
         user.id,
         user.lastName,
         user.firstName,
         user.emailAddress,
         mapRolesToStrings(user.roles),
-        skills.map((skill) => mapSkillToSkillPreview(skill)),
+        SkillPreviewResponse.fromArray(await getSkills(user.skills)),
         user.imageUrl,
         user.creationDate,
     );

--- a/hms-api/src/handlers/user/list.ts
+++ b/hms-api/src/handlers/user/list.ts
@@ -1,10 +1,10 @@
 import {buildResponse} from '../../rest/responses';
 import {listUsers} from '../../repository/user-repository';
 import UserListResponse from '../../rest/UserListResponse';
+import UserPreviewResponse from '../../rest/UserPreviewResponse';
 
 // eslint-disable-next-line require-jsdoc
 export async function list(event, context, callback) {
-  const users = await listUsers();
-  const userIds = users.map((user) => user.id);
-  callback(null, buildResponse(200, new UserListResponse(userIds)));
+  const previews = UserPreviewResponse.fromArray(await listUsers());
+  callback(null, buildResponse(200, new UserListResponse(previews)));
 }

--- a/hms-api/src/repository/participant-repository.ts
+++ b/hms-api/src/repository/participant-repository.ts
@@ -52,6 +52,15 @@ export async function getParticipant(id: Uuid)
   return item ? itemToParticipant(item) : undefined;
 }
 
+export async function getParticipants(ids: Uuid[])
+    : Promise<Participant[]> {
+  const participants: Participant[] = [];
+  for (const id of ids) {
+    participants.push(await getParticipant(id));
+  }
+  return participants;
+}
+
 export async function removeParticipant(id: Uuid) {
   await dynamoDBClient.send(new DeleteItemCommand({
     TableName: table,

--- a/hms-api/src/repository/user-repository.ts
+++ b/hms-api/src/repository/user-repository.ts
@@ -51,6 +51,14 @@ export async function getUser(id: Uuid): Promise<User | undefined> {
   return item ? itemToUser(item) : undefined;
 }
 
+export async function getUsers(ids: Uuid[]): Promise<User[]> {
+  const users: User[] = [];
+  for (const id of ids) {
+    users.push(await getUser(id));
+  }
+  return users;
+}
+
 export async function removeUser(id: Uuid) {
   // TODO determine if something was actually deleted
   await dynamoDBClient.send(new DeleteItemCommand({

--- a/hms-api/src/rest/CategoryListResponse.ts
+++ b/hms-api/src/rest/CategoryListResponse.ts
@@ -1,16 +1,17 @@
 /* eslint-disable require-jsdoc */
 
 import {Uuid} from '../util/uuids';
+import CategoryPreviewResponse from './CategoryPreviewResponse';
 
 export default class {
-  ids: Uuid[];
+  categories: CategoryPreviewResponse[];
   hackathonId: Uuid;
 
   constructor(
-      ids: Uuid[],
+      categories: CategoryPreviewResponse[],
       hackathonId: Uuid,
   ) {
-    this.ids = ids;
+    this.categories = categories;
     this.hackathonId = hackathonId;
   }
 }

--- a/hms-api/src/rest/CategoryPreviewResponse.ts
+++ b/hms-api/src/rest/CategoryPreviewResponse.ts
@@ -1,0 +1,33 @@
+/* eslint-disable require-jsdoc */
+
+import {Uuid} from '../util/uuids';
+import Category from '../repository/domain/Category';
+
+class CategoryPreviewResponse {
+  id: Uuid;
+  title: string;
+
+  constructor(
+      id: Uuid,
+      title: string,
+  ) {
+    this.id = id;
+    this.title = title;
+  }
+
+  static from = (category: Category): CategoryPreviewResponse =>
+    new CategoryPreviewResponse(
+        category.id,
+        category.title,
+    );
+
+  static fromArray(categories: Category[]): CategoryPreviewResponse[] {
+    const previews: CategoryPreviewResponse[] = [];
+    for (const category of categories) {
+      previews.push(CategoryPreviewResponse.from(category));
+    }
+    return previews;
+  }
+}
+
+export default CategoryPreviewResponse;

--- a/hms-api/src/rest/CategoryResponse.ts
+++ b/hms-api/src/rest/CategoryResponse.ts
@@ -1,22 +1,23 @@
 /* eslint-disable require-jsdoc */
 
 import {Uuid} from '../util/uuids';
+import HackathonPreviewResponse from './HackathonPreviewResponse';
 
 export default class {
   id: Uuid;
   title: string;
   description: string;
-  hackathonId: Uuid;
+  hackathon: HackathonPreviewResponse;
 
   constructor(
       id: Uuid,
       title: string,
       description: string,
-      hackathonId: Uuid,
+      hackathon: HackathonPreviewResponse,
   ) {
     this.id = id;
     this.title = title;
     this.description = description;
-    this.hackathonId = hackathonId;
+    this.hackathon = hackathon;
   }
 }

--- a/hms-api/src/rest/HackathonListResponse.ts
+++ b/hms-api/src/rest/HackathonListResponse.ts
@@ -1,10 +1,11 @@
 /* eslint-disable require-jsdoc */
-import {Uuid} from '../util/uuids';
+
+import HackathonPreviewResponse from './HackathonPreviewResponse';
 
 export default class {
-  ids: Uuid[];
+  hackathons: HackathonPreviewResponse[];
 
-  constructor(ids: Uuid[]) {
-    this.ids = ids;
+  constructor(hackathons: HackathonPreviewResponse[]) {
+    this.hackathons = hackathons;
   }
 }

--- a/hms-api/src/rest/HackathonPreviewResponse.ts
+++ b/hms-api/src/rest/HackathonPreviewResponse.ts
@@ -1,0 +1,33 @@
+/* eslint-disable require-jsdoc */
+
+import {Uuid} from '../util/uuids';
+import Hackathon from '../repository/domain/Hackathon';
+
+class HackathonPreviewResponse {
+  id: Uuid;
+  title: string;
+
+  constructor(
+      id: Uuid,
+      title: string,
+  ) {
+    this.id = id;
+    this.title = title;
+  }
+
+  static from = (hackathon: Hackathon): HackathonPreviewResponse =>
+    new HackathonPreviewResponse(
+        hackathon.id,
+        hackathon.title,
+    );
+
+  static fromArray(hackathons: Hackathon[]): HackathonPreviewResponse[] {
+    const previews: HackathonPreviewResponse[] = [];
+    for (const hackathon of hackathons) {
+      previews.push(HackathonPreviewResponse.from(hackathon));
+    }
+    return previews;
+  }
+}
+
+export default HackathonPreviewResponse;

--- a/hms-api/src/rest/HackathonResponse.ts
+++ b/hms-api/src/rest/HackathonResponse.ts
@@ -1,5 +1,9 @@
 /* eslint-disable require-jsdoc */
+
 import {Uuid} from '../util/uuids';
+import ParticipantPreviewResponse from './ParticipantPreviewResponse';
+import CategoryPreviewResponse from './CategoryPreviewResponse';
+import IdeaPreviewResponse from './IdeaPreviewResponse';
 
 export default class {
   id: Uuid;
@@ -8,25 +12,25 @@ export default class {
   endDate: Date;
   creationDate: Date;
   // Just going to set all of these as Uuids for right now
-  participantIds: Uuid[];
-  categoryIds: Uuid[];
-  ideaIds: Uuid[];
+  participants: ParticipantPreviewResponse[];
+  categories: CategoryPreviewResponse[];
+  ideas: IdeaPreviewResponse[];
 
   constructor(
       id: Uuid,
       title: string,
       startDate: Date,
       endDate: Date,
-      participantIds: Uuid[],
-      categoryIds: Uuid[],
-      ideaIds: Uuid[],
+      participants: ParticipantPreviewResponse[],
+      categories: CategoryPreviewResponse[],
+      ideas: IdeaPreviewResponse[],
   ) {
     this.id = id;
     this.title = title;
     this.startDate = startDate;
     this.endDate = endDate;
-    this.participantIds = participantIds;
-    this.categoryIds = categoryIds;
-    this.ideaIds = ideaIds;
+    this.participants = participants;
+    this.categories = categories;
+    this.ideas = ideas;
   }
 }

--- a/hms-api/src/rest/IdeaListResponse.ts
+++ b/hms-api/src/rest/IdeaListResponse.ts
@@ -1,16 +1,17 @@
 /* eslint-disable require-jsdoc */
 
+import IdeaPreviewResponse from './IdeaPreviewResponse';
 import {Uuid} from '../util/uuids';
 
 export default class {
-  ids: Uuid[];
+  ideas: IdeaPreviewResponse[];
   hackathonId: Uuid;
 
   constructor(
-      ids: Uuid[],
+      ideas: IdeaPreviewResponse[],
       hackathonId: Uuid,
   ) {
-    this.ids = ids;
+    this.ideas = ideas;
     this.hackathonId = hackathonId;
   }
 }

--- a/hms-api/src/rest/IdeaPreviewResponse.ts
+++ b/hms-api/src/rest/IdeaPreviewResponse.ts
@@ -1,0 +1,33 @@
+/* eslint-disable require-jsdoc */
+
+import {Uuid} from '../util/uuids';
+import Idea from '../repository/domain/Idea';
+
+class IdeaPreviewResponse {
+  id: Uuid;
+  title: string;
+
+  constructor(
+      id: Uuid,
+      title: string,
+  ) {
+    this.id = id;
+    this.title = title;
+  }
+
+  static from = (idea: Idea): IdeaPreviewResponse =>
+    new IdeaPreviewResponse(
+        idea.id,
+        idea.title,
+    );
+
+  static fromArray(ideas: Idea[]): IdeaPreviewResponse[] {
+    const previews: IdeaPreviewResponse[] = [];
+    for (const idea of ideas) {
+      previews.push(IdeaPreviewResponse.from(idea));
+    }
+    return previews;
+  }
+}
+
+export default IdeaPreviewResponse;

--- a/hms-api/src/rest/IdeaResponse.ts
+++ b/hms-api/src/rest/IdeaResponse.ts
@@ -2,43 +2,46 @@
 
 import {Uuid} from '../util/uuids';
 import SkillPreviewResponse from './SkillPreviewResponse';
+import HackathonPreviewResponse from './HackathonPreviewResponse';
+import CategoryPreviewResponse from './CategoryPreviewResponse';
+import ParticipantPreviewResponse from './ParticipantPreviewResponse';
 
 export default class {
   id: Uuid;
-  ownerId: Uuid;
-  hackathonId: Uuid;
-  participantIds: Uuid[];
+  owner: ParticipantPreviewResponse;
+  hackathon: HackathonPreviewResponse;
+  participants: ParticipantPreviewResponse[];
   title: string;
   description: string;
   problem: string;
   goal: string;
   requiredSkills: SkillPreviewResponse[];
-  categoryId: Uuid;
+  category: CategoryPreviewResponse;
   creationDate: Date;
 
   constructor(
       id: Uuid,
-      ownerId: Uuid,
-      hackathonId: Uuid,
-      participantIds: Uuid[],
+      owner: ParticipantPreviewResponse,
+      hackathon: HackathonPreviewResponse,
+      participants: ParticipantPreviewResponse[],
       title: string,
       description: string,
       problem: string,
       goal: string,
       requiredSkills: SkillPreviewResponse[],
-      categoryId: Uuid,
+      category: CategoryPreviewResponse,
       creationDate: Date,
   ) {
     this.id = id;
-    this.ownerId = ownerId;
-    this.hackathonId = hackathonId;
-    this.participantIds = participantIds;
+    this.owner = owner;
+    this.hackathon = hackathon;
+    this.participants = participants;
     this.title = title;
     this.description = description;
     this.problem = problem;
     this.goal = goal;
     this.requiredSkills = requiredSkills;
-    this.categoryId = categoryId;
+    this.category = category;
     this.creationDate = creationDate;
   }
 }

--- a/hms-api/src/rest/ParticipantListResponse.ts
+++ b/hms-api/src/rest/ParticipantListResponse.ts
@@ -1,16 +1,17 @@
 /* eslint-disable require-jsdoc */
 
+import ParticipantPreviewResponse from './ParticipantPreviewResponse';
 import {Uuid} from '../util/uuids';
 
 export default class {
-  ids: Uuid[];
+  participants: ParticipantPreviewResponse[];
   hackathonId: Uuid;
 
   constructor(
-      ids: Uuid[],
+      participants: ParticipantPreviewResponse[],
       hackathonId: Uuid,
   ) {
-    this.ids = ids;
+    this.participants = participants;
     this.hackathonId = hackathonId;
   }
 }

--- a/hms-api/src/rest/ParticipantPreviewResponse.ts
+++ b/hms-api/src/rest/ParticipantPreviewResponse.ts
@@ -1,0 +1,39 @@
+/* eslint-disable require-jsdoc */
+
+import {Uuid} from '../util/uuids';
+import UserPreviewResponse from './UserPreviewResponse';
+import Participant from '../repository/domain/Participant';
+import User from '../repository/domain/User';
+
+class ParticipantPreviewResponse {
+  id: Uuid;
+  user: UserPreviewResponse;
+
+  constructor(
+      id: Uuid,
+      user: UserPreviewResponse,
+  ) {
+    this.id = id;
+    this.user = user;
+  }
+
+  static from = (participant: Participant, user: User)
+      : ParticipantPreviewResponse =>
+    new ParticipantPreviewResponse(
+        participant.id,
+        UserPreviewResponse.from(user),
+    );
+
+  static fromArray(participants: Participant[], users: User[])
+      : ParticipantPreviewResponse[] {
+    const previews: ParticipantPreviewResponse[] = [];
+    for (const participant of participants) {
+      previews.push(ParticipantPreviewResponse.from(
+          participant,
+          users.find((user) => user.id === participant.userId)));
+    }
+    return previews;
+  }
+}
+
+export default ParticipantPreviewResponse;

--- a/hms-api/src/rest/ParticipantResponse.ts
+++ b/hms-api/src/rest/ParticipantResponse.ts
@@ -1,22 +1,24 @@
 /* eslint-disable require-jsdoc */
 
 import {Uuid} from '../util/uuids';
+import UserPreviewResponse from './UserPreviewResponse';
+import HackathonPreviewResponse from './HackathonPreviewResponse';
 
 export default class {
   id: Uuid;
-  userId: Uuid;
-  hackathonId: Uuid;
+  user: UserPreviewResponse;
+  hackathon: HackathonPreviewResponse;
   creationDate: Date;
 
   constructor(
       id: Uuid,
-      userId: Uuid,
-      hackathonId: Uuid,
+      user: UserPreviewResponse,
+      hackathon: HackathonPreviewResponse,
       creationDate: Date,
   ) {
     this.id = id;
-    this.userId = userId;
-    this.hackathonId = hackathonId;
+    this.user = user;
+    this.hackathon = hackathon;
     this.creationDate = creationDate;
   }
 }

--- a/hms-api/src/rest/SkillPreviewResponse.ts
+++ b/hms-api/src/rest/SkillPreviewResponse.ts
@@ -14,9 +14,20 @@ class SkillPreviewResponse {
     this.id = id;
     this.name = name;
   }
-}
 
-export const mapSkillToSkillPreview = (skill: Skill) =>
-  new SkillPreviewResponse(skill.id, skill.name);
+  static from = (skill: Skill): SkillPreviewResponse =>
+    new SkillPreviewResponse(
+        skill.id,
+        skill.name,
+    );
+
+  static fromArray(skills: Skill[]): SkillPreviewResponse[] {
+    const previews: SkillPreviewResponse[] = [];
+    for (const skill of skills) {
+      previews.push(SkillPreviewResponse.from(skill));
+    }
+    return previews;
+  }
+}
 
 export default SkillPreviewResponse;

--- a/hms-api/src/rest/UserListResponse.ts
+++ b/hms-api/src/rest/UserListResponse.ts
@@ -1,11 +1,11 @@
 /* eslint-disable require-jsdoc */
 
-import {Uuid} from '../util/uuids';
+import UserPreviewResponse from './UserPreviewResponse';
 
 export default class {
-  ids: Uuid[];
+  users: UserPreviewResponse[];
 
-  constructor(ids: Uuid[]) {
-    this.ids = ids;
+  constructor(users: UserPreviewResponse[]) {
+    this.users = users;
   }
 }

--- a/hms-api/src/rest/UserPreviewResponse.ts
+++ b/hms-api/src/rest/UserPreviewResponse.ts
@@ -1,0 +1,41 @@
+/* eslint-disable require-jsdoc */
+
+import {Uuid} from '../util/uuids';
+import User from '../repository/domain/User';
+
+class UserPreviewResponse {
+  id: Uuid;
+  lastName: string;
+  firstName: string;
+  imageUrl: string;
+
+  constructor(
+      id: Uuid,
+      lastName: string,
+      firstName: string,
+      imageUrl: string,
+  ) {
+    this.id = id;
+    this.lastName = lastName;
+    this.firstName = firstName;
+    this.imageUrl = imageUrl;
+  }
+
+  static from = (user: User): UserPreviewResponse =>
+    new UserPreviewResponse(
+        user.id,
+        user.lastName,
+        user.firstName,
+        user.imageUrl,
+    );
+
+  static fromArray(users: User[]): UserPreviewResponse[] {
+    const previews: UserPreviewResponse[] = [];
+    for (const user of users) {
+      previews.push(UserPreviewResponse.from(user));
+    }
+    return previews;
+  }
+}
+
+export default UserPreviewResponse;

--- a/hms-api/src/service/user-service.ts
+++ b/hms-api/src/service/user-service.ts
@@ -1,0 +1,9 @@
+/* eslint-disable require-jsdoc */
+
+import Participant from '../repository/domain/Participant';
+import User from '../repository/domain/User';
+import {getUsers} from '../repository/user-repository';
+
+export async function usersFor(participants: Participant[]): Promise<User[]> {
+  return await getUsers(participants.map((p) => p.userId));
+}


### PR DESCRIPTION
I'm not too happy with how this is implemented just yet to be honest but we will have to see how everything evolves as we add use cases and increase complexity.  Basically all of the entities now have "preview" responses that contain a limited amount of data.  The "list" response for an entity will include these "preview" responses and any entity has another entity as one of it's fields will also use these "preview" responses in place of the full response.

One thing I'm not so keen on is how the participant has a user... we could maybe somehow merge them :thinking: 