### PR TITLE
remove sorting causing a critical error

### DIFF
--- a/hms-app/src/components/card-details/IdeaDetails.tsx
+++ b/hms-app/src/components/card-details/IdeaDetails.tsx
@@ -271,7 +271,6 @@ export default function IdeaDetails(props: IProps) {
       participantInfo.ideaId,
       participantInfo.participantId
     ).then((response) => {
-      console.log('response', response)
       setButtonisDisabled(false)
       if (JSON.stringify(response).toString().includes('error')) {
         setParticipantCheck(false)

--- a/hms-app/src/pages/AllIdeas.tsx
+++ b/hms-app/src/pages/AllIdeas.tsx
@@ -60,13 +60,9 @@ function AllIdeas() {
     setSearchTerm(event.target.value)
   }
 
-  const filteredIdeas = relevantIdeaList
-    .filter((item) => {
-      return item.title?.toLowerCase().includes(searchTerm.toLowerCase())
-    })
-    .sort((a, b) => {
-      return a.creationDate < b.creationDate ? -1 : 1
-    })
+  const filteredIdeas = relevantIdeaList.filter((item) => {
+    return item.title?.toLowerCase().includes(searchTerm.toLowerCase())
+  })
 
   const findParticipant = () => {
     let participant: ParticipantPreview


### PR DESCRIPTION
The sorting of ideas by creation date somehow breaks the correct display of ideas and their participant statuses.
I removed the sorting to fix it.